### PR TITLE
修复下载过程中崩溃的问题。

### DIFF
--- a/src/org/zywx/wbpalmstar/plugin/uexdownloadermgr/EUExDownloaderMgr.java
+++ b/src/org/zywx/wbpalmstar/plugin/uexdownloadermgr/EUExDownloaderMgr.java
@@ -78,7 +78,7 @@ public class EUExDownloaderMgr extends EUExBase {
 		if (m_databaseHelper != null) {
 			return;
 		}
-		m_databaseHelper = new DatabaseHelper(mContext, "piugin_downloadermgr_downloader.db", 1);
+		m_databaseHelper = new DatabaseHelper(mContext, "plugin_downloadermgr_downloader.db", 1);
 		m_database = m_databaseHelper.getReadableDatabase();
 		m_database.execSQL(F_CREATETABLE_SQL);
 	}

--- a/src/org/zywx/wbpalmstar/plugin/uexdownloadermgr/EUExDownloaderMgr.java
+++ b/src/org/zywx/wbpalmstar/plugin/uexdownloadermgr/EUExDownloaderMgr.java
@@ -52,8 +52,8 @@ public class EUExDownloaderMgr extends EUExBase {
 	public final static int F_STATE_CREATE_DOWNLOADER = 0;
 	public final static int F_STATE_DOWNLOADING = 1;
 	public static final String F_CREATETABLE_SQL = "CREATE TABLE IF  NOT EXISTS Downloader(_id INTEGER PRIMARY KEY,url TEXT,filePath TEXT,fileSize TEXT,downSize TEXT,time TEXT)";
-	DatabaseHelper m_databaseHelper = null;
-	SQLiteDatabase m_database = null;
+	private DatabaseHelper m_databaseHelper = null;
+	private SQLiteDatabase m_database = null;
 	static final String SCRIPT_HEADER = "javascript:";
 
 	private HashMap<Integer, DownLoadAsyncTask> m_objectMap;
@@ -78,7 +78,7 @@ public class EUExDownloaderMgr extends EUExBase {
 		if (m_databaseHelper != null) {
 			return;
 		}
-		m_databaseHelper = new DatabaseHelper(mContext, "Downloader.db", 1);
+		m_databaseHelper = new DatabaseHelper(mContext, "piugin_downloadermgr_downloader.db", 1);
 		m_database = m_databaseHelper.getReadableDatabase();
 		m_database.execSQL(F_CREATETABLE_SQL);
 	}

--- a/uexDownloaderMgr/info.xml
+++ b/uexDownloaderMgr/info.xml
@@ -1,8 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <uexplugins>
     <plugin
-        uexName="uexDownloaderMgr" version="3.0.11" build="11">
-        <info>11:修复调用cancelDownload之后，即使不清除已下载的临时文件，下次下载时不能断点续传的问题。</info>
+        uexName="uexDownloaderMgr" version="3.0.12" build="12">
+        <info>12:修复下载过程中崩溃的问题（由于与其他插件使用的数据库同名造成的）。</info>
+        <build>11:修复调用cancelDownload之后，即使不清除已下载的临时文件，下次下载时不能断点续传的问题。</build>
         <build>10:增加新的 header以及plugin里面的子应用的appId和appkey都按照主应用为准</build>
         <build>9:增加appVerify校验头</build>
         <build>8:https下载时可以支持预置证书；增大下载缓冲区；支持中文url;增强稳定性</build>


### PR DESCRIPTION
这个问题是由于数据库命名不规范，与其他插件使用的数据库同名造成的。
